### PR TITLE
Add support for OAuth2 SSO

### DIFF
--- a/app/org/elastic4play/Errors.scala
+++ b/app/org/elastic4play/Errors.scala
@@ -18,6 +18,7 @@ case class UpdateError(status: Option[String], message: String, attributes: JsOb
 case class InternalError(message: String) extends Exception(message)
 case class SearchError(message: String, cause: Throwable) extends Exception(message, cause)
 case class AuthenticationError(message: String) extends Exception(message)
+case class OAuth2Redirect(redirectUrl: String, params: Map[String, Seq[String]]) extends Exception(redirectUrl)
 case class AuthorizationError(message: String) extends Exception(message)
 case class MultiError(message: String, exceptions: Seq[Exception]) extends Exception(message + exceptions.map(_.getMessage).mkString(" :\n\t- ", "\n\t- ", ""))
 

--- a/app/org/elastic4play/services/UserSrv.scala
+++ b/app/org/elastic4play/services/UserSrv.scala
@@ -1,7 +1,5 @@
 package org.elastic4play.services
 
-import java.util.concurrent.atomic.AtomicBoolean
-
 import scala.concurrent.Future
 
 import play.api.libs.json.JsObject
@@ -16,8 +14,6 @@ trait AuthContext {
   def userName: String
   def requestId: String
   def roles: Seq[Role]
-  private val baseAudit = new AtomicBoolean(true)
-  def getBaseAudit: Boolean = baseAudit.get && baseAudit.getAndSet(false)
 }
 
 trait UserSrv {

--- a/app/org/elastic4play/services/UserSrv.scala
+++ b/app/org/elastic4play/services/UserSrv.scala
@@ -42,6 +42,7 @@ trait AuthSrv {
 
   def authenticate(username: String, password: String)(implicit request: RequestHeader): Future[AuthContext] = Future.failed(AuthenticationError("Operation not supported"))
   def authenticate(key: String)(implicit request: RequestHeader): Future[AuthContext] = Future.failed(AuthenticationError("Operation not supported"))
+  def authenticate()(implicit request: RequestHeader): Future[AuthContext] = Future.failed(AuthenticationError("Operation not supported"))
   def changePassword(username: String, oldPassword: String, newPassword: String)(implicit authContext: AuthContext): Future[Unit] = Future.failed(AuthorizationError("Operation not supported"))
   def setPassword(username: String, newPassword: String)(implicit authContext: AuthContext): Future[Unit] = Future.failed(AuthorizationError("Operation not supported"))
   def renewKey(username: String)(implicit authContext: AuthContext): Future[String] = Future.failed(AuthorizationError("Operation not supported"))

--- a/app/org/elastic4play/services/auth/MultiAuthSrv.scala
+++ b/app/org/elastic4play/services/auth/MultiAuthSrv.scala
@@ -4,11 +4,9 @@ import javax.inject.{ Inject, Singleton }
 
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
-
 import play.api.mvc.RequestHeader
 import play.api.{ Configuration, Logger }
-
-import org.elastic4play.AuthenticationError
+import org.elastic4play.{ AuthenticationError, OAuth2Redirect }
 import org.elastic4play.services.AuthCapability.Type
 import org.elastic4play.services.{ AuthContext, AuthSrv }
 
@@ -59,6 +57,13 @@ class MultiAuthSrv(
   override def authenticate(key: String)(implicit request: RequestHeader): Future[AuthContext] =
     forAllAuthProvider(_.authenticate(key))
       .recoverWith { case _ ⇒ Future.failed(AuthenticationError("Authentication failure")) }
+
+  override def authenticate()(implicit request: RequestHeader): Future[AuthContext] =
+    forAllAuthProvider(_.authenticate)
+      .recoverWith {
+        case e: OAuth2Redirect ⇒ Future.failed(e)
+        case _                 ⇒ Future.failed(AuthenticationError("Authentication failure"))
+      }
 
   override def changePassword(username: String, oldPassword: String, newPassword: String)(implicit authContext: AuthContext): Future[Unit] =
     forAllAuthProvider(_.changePassword(username, oldPassword, newPassword))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "1.4.2"
+version := "1.5.0-SNAPSHOT"


### PR DESCRIPTION
This pull request addresses #42 and is needed for PR [430](https://github.com/TheHive-Project/TheHive/pull/430) from TheHive.

It adds an authenticate method that uses only the request and provides a mechanism for redirecting to the organization's authorization URL when no valid credentials are received.

See more details in the `TheHive` PR.

Comments, suggestions, improvements always welcome.

