### PR TITLE
Added Organizational Format to support multiple organizations

### DIFF
--- a/app/org/elastic4play/models/Attributes.scala
+++ b/app/org/elastic4play/models/Attributes.scala
@@ -47,6 +47,7 @@ object AttributeFormat {
   val stringFmt = StringAttributeFormat
   val userFmt = UserAttributeFormat
   val booleanFmt = BooleanAttributeFormat
+  val orgFmt = OrganizationAttributeFormat
   val numberFmt = NumberAttributeFormat
   val attachmentFmt = AttachmentAttributeFormat
   val metricsFmt = MetricsAttributeFormat

--- a/app/org/elastic4play/models/OrganizationAttributeFormat.scala
+++ b/app/org/elastic4play/models/OrganizationAttributeFormat.scala
@@ -1,0 +1,7 @@
+package org.elastic4play.models
+
+class OrganizationAttributeFormat extends StringAttributeFormat {
+  override val name: String = "organization"
+}
+
+object OrganizationAttributeFormat extends OrganizationAttributeFormat


### PR DESCRIPTION
Have added the ability for TheHive to support multiple organizations in the same way ti can support multiple users. Wanted to add in an additional format so the Hive Case model will look as such:

val orgName: A[String] = attribute("orgName", F.orgFmt, "Name of organization")
